### PR TITLE
Set submission to "validating" once a worker fetches it.

### DIFF
--- a/app/controllers/fetch_controller.rb
+++ b/app/controllers/fetch_controller.rb
@@ -106,9 +106,14 @@ class FetchController < ApplicationController
   end
 
   def submission
-    @submission = Submission.where("`result` = 'queued' AND `contest_id` IS NOT NULL").order('id').first
-    if not @submission
-      @submission = Submission.where("`result` = 'queued'").order('id').first
+    Submission.transaction do
+      @submission = Submission.lock.where("`result` = 'queued' AND `contest_id` IS NOT NULL").order('id').first
+      if not @submission
+        @submission = Submission.lock.where("`result` = 'queued'").order('id').first
+      end
+      if @submission
+        @submission.update(:result => "Validating")
+      end
     end
     #@submission = Submission.where("`result` = 'queued' AND `contest_id` IS NULL").order('id desc').first
     #if not @submission


### PR DESCRIPTION
This solves the problem where, in the context of multiple workers,
multiple workers may receive the same task.

Note that this creates a potential issue where, when a worker dies after
fetching the task and before submitting the results, the task will be
"orphaned" and requires manual rejudging. Solving this issue may
require, say, a separate field in the database recording the last time a
task is sent and retrying those that seem to be stale.